### PR TITLE
Fix desync with framed audio formats and mismatched sample rates

### DIFF
--- a/crates/apex-client/src/client/audio/game_audio.rs
+++ b/crates/apex-client/src/client/audio/game_audio.rs
@@ -4,7 +4,7 @@ use apex_framework::{
   audio::{arc_buffer::ArcSamplesBuffer, audio_engine::AudioEngine, audio_mixer::AudioController, lead_in::lead_in},
   time::{clock::AbstractClock, time::Time},
 };
-use rodio::{source::UniformSourceIterator, Decoder, Device, DeviceTrait as _, Source, SupportedStreamConfig};
+use rodio::{source::UniformSourceIterator, Decoder, Device, DeviceTrait as _, Sample, Source, SupportedStreamConfig};
 
 pub struct GameAudio {
   audio_engine: AudioEngine,
@@ -136,5 +136,67 @@ impl GameAudioController {
 
   pub fn set_effect_volume(&self, volume: f32) {
     self.0.set_sound_volume(volume);
+  }
+}
+
+pub struct FramelessSource<I>
+where
+  I: Source,
+  I::Item: Sample,
+{
+  inner: I,
+}
+
+impl<I> FramelessSource<I>
+where
+  I: Source,
+  I::Item: Sample,
+{
+  pub fn new(source: I) -> Self {
+    Self { inner: source }
+  }
+}
+
+impl<I> From<I> for FramelessSource<I>
+where
+  I: Source,
+  I::Item: Sample,
+{
+  fn from(value: I) -> Self {
+    Self::new(value)
+  }
+}
+
+impl<I> Iterator for FramelessSource<I>
+where
+  I: Source,
+  I::Item: Sample,
+{
+  type Item = I::Item;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    self.inner.next()
+  }
+}
+
+impl<I> Source for FramelessSource<I>
+where
+  I: Source,
+  I::Item: Sample,
+{
+  fn current_frame_len(&self) -> Option<usize> {
+    None
+  }
+
+  fn channels(&self) -> u16 {
+    self.inner.channels()
+  }
+
+  fn sample_rate(&self) -> u32 {
+    self.inner.sample_rate()
+  }
+
+  fn total_duration(&self) -> Option<std::time::Duration> {
+    self.inner.total_duration()
   }
 }

--- a/crates/apex-client/src/client/client.rs
+++ b/crates/apex-client/src/client/client.rs
@@ -45,7 +45,7 @@ use apex_framework::{
 
 use super::{
   action::ClientAction,
-  audio::game_audio::GameAudio,
+  audio::game_audio::{FramelessSource, GameAudio},
   event::ClientEvent,
   gameplay::beatmap_cache::{BeatmapCache, BeatmapInfo},
   graphics::{FrameLimiterOptions, RenderingBackend},
@@ -543,6 +543,7 @@ impl Client {
     let source = Decoder::new(file).unwrap();
 
     let config = audio.device().default_output_config().unwrap();
+    let source = FramelessSource::new(source);
     let source = UniformSourceIterator::new(source, config.channels(), config.sample_rate().0);
 
     // TODO: calculate length of the audio

--- a/crates/apex-client/src/client/screen/gameplay_screen/gameplay_screen.rs
+++ b/crates/apex-client/src/client/screen/gameplay_screen/gameplay_screen.rs
@@ -5,7 +5,7 @@ use jiff::Timestamp;
 use rodio::{source::UniformSourceIterator, Decoder, DeviceTrait};
 
 use crate::client::{
-  audio::game_audio::{GameAudio, GameAudioController},
+  audio::game_audio::{FramelessSource, GameAudio, GameAudioController},
   client::Client,
   event::ClientEvent,
   gameplay::{
@@ -180,6 +180,7 @@ impl GameplayScreen {
     let audio_path = beatmap_path.parent().unwrap().join(&beatmap.audio);
     let file = BufReader::new(File::open(audio_path).unwrap());
     let source = Decoder::new(file).unwrap();
+    let source = FramelessSource::new(source);
     let source = UniformSourceIterator::new(source, config.channels(), config.sample_rate().0);
 
     let end_time = beatmap.hit_objects.last().unwrap().time;


### PR DESCRIPTION
The audio was getting very slightly stretched out when sample rate conversion was occurring from a Source that was supplying frame length information (1 second longer for a 3m40s MP3 audio file).